### PR TITLE
Fix Stockfish worker path

### DIFF
--- a/public/stockfish.js
+++ b/public/stockfish.js
@@ -1,2 +1,6 @@
 // Stockfish WebAssembly worker
-importScripts('/stockfish-16.1.js');
+// The original implementation attempted to load a local copy of the Stockfish
+// engine ("/stockfish-16.1.js"), but this file was missing from the repository
+// which caused the worker to fail and the AI never returned a move. Instead we
+// load Stockfish from a CDN.
+importScripts('https://cdn.jsdelivr.net/npm/stockfish@16/stockfish.js');


### PR DESCRIPTION
## Summary
- fix the Stockfish worker script path so the engine loads correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*